### PR TITLE
Replaced SLDS Html component with a LWC base component

### DIFF
--- a/force-app/main/default/lwc/dynamicFlowProgressLWC/dynamicFlowProgressLWC.html
+++ b/force-app/main/default/lwc/dynamicFlowProgressLWC/dynamicFlowProgressLWC.html
@@ -8,7 +8,7 @@
 /* MODIFICATION LOG
 *
 * 	Date			Developer			Story		Description
-*   09/19/2022      Martin Futas        n/a         Replaced Progress Bar slds component with a LWC base compoonent due to issue where last progress bar on the same page overrides all other progress bars with its value due to how css is being set in controller.
+*   09/19/2022      Martin Futas        n/a         Replaced Progress Bar SLDS component with a LWC base component due to issue where last progress bar on the same flow screen overrides all other progress bars with its value due to how css is being set in controller.
 *   09/19/2022      Mitch Lynch         n/a         Fixed typo in indicatorType property that listed "NavMenu" instead of "VertNav". Removed tabindex attribute from the Path indicator markup. Added a new showFinalComplete state for Vertical and VertNav, rather than trying to trick them into showing the showCurrent state.
 *   09/13/2022      Mitch Lynch         n/a         Configured masterLabel to "Dynamic Flow Progress".
 *   09/01/2022      Mitch Lynch         n/a         Resolved bug where VerNav wouldn't display the final step as the current step. Fixed issue where currentStepPercentage was not overriding VertNav and Bar.

--- a/force-app/main/default/lwc/dynamicFlowProgressLWC/dynamicFlowProgressLWC.html
+++ b/force-app/main/default/lwc/dynamicFlowProgressLWC/dynamicFlowProgressLWC.html
@@ -8,6 +8,7 @@
 /* MODIFICATION LOG
 *
 * 	Date			Developer			Story		Description
+*   09/19/2022      Martin Futas        n/a         Replaced Progress Bar slds component with a LWC base compoonent due to issue where last progress bar on the same page overrides all other progress bars with its value due to how css is being set in controller.
 *   09/19/2022      Mitch Lynch         n/a         Fixed typo in indicatorType property that listed "NavMenu" instead of "VertNav". Removed tabindex attribute from the Path indicator markup. Added a new showFinalComplete state for Vertical and VertNav, rather than trying to trick them into showing the showCurrent state.
 *   09/13/2022      Mitch Lynch         n/a         Configured masterLabel to "Dynamic Flow Progress".
 *   09/01/2022      Mitch Lynch         n/a         Resolved bug where VerNav wouldn't display the final step as the current step. Fixed issue where currentStepPercentage was not overriding VertNav and Bar.
@@ -287,11 +288,13 @@
                 <strong>{progressLabel}</strong>
             </span>
         </div>
-        <div class="slds-progress-bar slds-progress-bar_circular slds-progress-bar_large" aria-valuemin="0" aria-valuemax="100" aria-valuenow={pathProgress} aria-labelledby="progress-bar-label-id-6" aria-label={progressLabel} role="progressbar">
+        <!-- <div class="slds-progress-bar slds-progress-bar_circular slds-progress-bar_large" aria-valuemin="0" aria-valuemax="100" aria-valuenow={pathProgress} aria-labelledby="progress-bar-label-id-6" aria-label={progressLabel} role="progressbar">
             <span class="slds-progress-bar__value progress-style">
                 <span class="slds-assistive-text">{progressLabel}</span>
             </span>
-        </div>
+        </div> -->
+        <lightning-progress-bar value={currentStepPercentage} size="large" variant="circular"></lightning-progress-bar>
+
     </template>
     <!-- ##### END: Bar ##### -->
 

--- a/force-app/main/default/lwc/dynamicFlowProgressLWC/dynamicFlowProgressLWC.js
+++ b/force-app/main/default/lwc/dynamicFlowProgressLWC/dynamicFlowProgressLWC.js
@@ -210,7 +210,7 @@ export default class DynamicFlowProgressLWC extends LightningElement {
                 this.progressLabel = `${this.pathProgress}% ${this.label.DFP_Complete}`;
 
                 // setting dynamic css width value for the Bar and Ring indicator types
-                document.documentElement.style.setProperty('--value', this.pathProgress);
+                //document.documentElement.style.setProperty('--value', this.pathProgress);
             }
         }
 
@@ -222,7 +222,7 @@ export default class DynamicFlowProgressLWC extends LightningElement {
             this.progressLabel = `${this.pathProgress}% ${this.label.DFP_Complete}`;
             
             // setting dynamic css width value for the Horizontal indicator type
-            document.documentElement.style.setProperty('--value', this.pathProgress);
+            //document.documentElement.style.setProperty('--value', this.pathProgress);
         }
 
         // store list of steps to iterate over in the html


### PR DESCRIPTION
Replaced Progress Bar SLDS component with a LWC base component due to issue where last progress bar on the same flow screen overrides all other progress bars with its value due to how css is being set in controller.